### PR TITLE
refactor: bump `hashbrown` to v0.15.0, use `HashTable` api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -63,6 +69,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "foldhash"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
+
+[[package]]
 name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -70,9 +88,14 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "hermit-abi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["asynchronous", "concurrency", "data-structures"]
 
 [dependencies]
 crossbeam-utils = "0.8.20"
-hashbrown = { version = "0.14.5", default-features = false, features = ["raw"] }
+hashbrown = { version = "0.15.0" }
 
 [dev-dependencies]
 tokio = { version = "1.41.0", features = ["full"] }

--- a/src/shard.rs
+++ b/src/shard.rs
@@ -4,7 +4,7 @@ mod futures;
 
 use futures::{Read, Write};
 
-pub(crate) type Inner<K, V> = hashbrown::raw::RawTable<(K, V)>;
+pub(crate) type Inner<K, V> = hashbrown::HashTable<(K, V)>;
 pub(crate) type ShardReader<'a, K, V> = RwLockReadGuard<'a, Inner<K, V>>;
 pub(crate) type ShardWriter<'a, K, V> = RwLockWriteGuard<'a, Inner<K, V>>;
 


### PR DESCRIPTION
I had previously thought that the older raw API was more performant, but after some additional testing the new API appears to work well. It allows me to remove some unsafe code, so updating seems like a win-win.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor to use `hashbrown` v0.15.0 `HashTable` API, removing unsafe code in `shard.rs` and `shard_map.rs`.
> 
>   - **Dependencies**:
>     - Bump `hashbrown` to version 0.15.0 in `Cargo.toml` and `Cargo.lock`.
>     - Add dependencies `allocator-api2`, `equivalent`, and `foldhash` in `Cargo.lock`.
>   - **Refactor**:
>     - Replace `hashbrown::raw::RawTable` with `hashbrown::HashTable` in `shard.rs`.
>     - Use `hashbrown::hash_table::Entry` API in `shard_map.rs` for `insert`, `get`, `get_mut`, and `remove` functions.
>     - Remove `hash_u64()` function in `shard_map.rs` and replace with `hash_one()` method.
>   - **Safety**:
>     - Remove unsafe code related to raw table operations in `shard_map.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=fortress-build%2Fwhirlwind&utm_source=github&utm_medium=referral)<sup> for bcc542bbb4e9a5e84d69f04889a61ea769180163. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->