### PR TITLE
implemented `with_entry`, `compute` and `compute_if_absent`

### DIFF
--- a/src/shard_map.rs
+++ b/src/shard_map.rs
@@ -477,7 +477,8 @@ where
     ///             }
     ///             Entry::Vacant(_) => None,
     ///         }
-    ///     }).await;
+    ///     })
+    ///     .await;
     ///
     ///     assert_eq!(result, Some("bar"));
     ///     assert_eq!(map.contains_key(&"foo").await, false);
@@ -515,14 +516,16 @@ where
     ///     map.compute("foo", |current| {
     ///         assert_eq!(current, None);
     ///         Some("bar")
-    ///     }).await;
+    ///     })
+    ///     .await;
     ///     assert_eq!(map.get(&"foo").await.unwrap().value(), &"bar");
     ///
     ///     // Update existing key.
     ///     map.compute("foo", |current| {
     ///         assert_eq!(current, Some("bar"));
     ///         Some("baz")
-    ///     }).await;
+    ///     })
+    ///     .await;
     ///     assert_eq!(map.get(&"foo").await.unwrap().value(), &"baz");
     /// });
     /// ```

--- a/src/shard_map.rs
+++ b/src/shard_map.rs
@@ -448,4 +448,145 @@ where
             shard.write().await.clear();
         }
     }
+
+    /// Provides access to the entry associated with the given key for in-place manipulation.
+    ///
+    /// This method allows you to interact with the map's entry for the specified key using a closure.
+    /// The closure receives the key and the entry (either occupied or vacant) and can modify the map
+    /// accordingly.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use tokio::runtime::Runtime;
+    /// use std::sync::Arc;
+    /// use whirlwind::ShardMap;
+    /// use hashbrown::hash_table::Entry;
+    ///
+    /// let rt = Runtime::new().unwrap();
+    /// let map = Arc::new(ShardMap::new());
+    ///
+    /// rt.block_on(async {
+    ///     map.insert("foo", "bar").await;
+    ///
+    ///     let result = map.with_entry("foo", |key, entry| {
+    ///         match entry {
+    ///             Entry::Occupied(entry) => {
+    ///                 let ((_, value), _) = entry.remove();
+    ///                 Some(value)
+    ///             }
+    ///             Entry::Vacant(_) => None,
+    ///         }
+    ///     }).await;
+    ///
+    ///     assert_eq!(result, Some("bar"));
+    ///     assert_eq!(map.contains_key(&"foo").await, false);
+    /// });
+    /// ```
+    pub async fn with_entry<R>(&self, key: K, f: impl FnOnce(K, Entry<(K, V)>) -> R) -> R {
+        let (shard, hash) = self.shard(&key);
+        let mut writer = shard.write().await;
+        let entry = writer.entry(
+            hash,
+            |(k, _)| k == &key,
+            |(k, _)| self.inner.hasher.hash_one(k),
+        );
+        f(key, entry)
+    }
+
+    /// Computes a new value for the specified key using the provided closure.
+    ///
+    /// The closure receives the current value associated with the key (or `None` if the key does not
+    /// exist) and returns an `Option<V>`. If the closure returns `Some(value)`, the key is associated
+    /// with the new value. If it returns `None`, the key is removed from the map (if it existed).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use tokio::runtime::Runtime;
+    /// use std::sync::Arc;
+    /// use whirlwind::ShardMap;
+    ///
+    /// let rt = Runtime::new().unwrap();
+    /// let map = Arc::new(ShardMap::new());
+    ///
+    /// rt.block_on(async {
+    ///     // Insert a new key-value pair if absent.
+    ///     map.compute("foo", |current| {
+    ///         assert_eq!(current, None);
+    ///         Some("bar")
+    ///     }).await;
+    ///     assert_eq!(map.get(&"foo").await.unwrap().value(), &"bar");
+    ///
+    ///     // Update existing key.
+    ///     map.compute("foo", |current| {
+    ///         assert_eq!(current, Some("bar"));
+    ///         Some("baz")
+    ///     }).await;
+    ///     assert_eq!(map.get(&"foo").await.unwrap().value(), &"baz");
+    /// });
+    /// ```
+    pub async fn compute<F>(&self, key: K, f: F)
+    where
+        F: FnOnce(Option<V>) -> Option<V>,
+    {
+        self.with_entry(key, |key, entry| match entry {
+            Entry::Occupied(entry) => {
+                let ((_, value), vacant) = entry.remove();
+                if let Some(new_value) = f(Some(value)) {
+                    vacant.insert((key, new_value));
+                }
+            }
+            Entry::Vacant(slot) => {
+                if let Some(value) = f(None) {
+                    slot.insert((key, value));
+                }
+            }
+        })
+        .await
+    }
+
+    /// Inserts a value for the specified key if it is not already present.
+    ///
+    /// If the key does not exist, the provided closure is called to generate a value, which is then
+    /// inserted. If the key exists, no action is taken, and the closure is not called. Returns `true`
+    /// if a new entry was inserted, `false` otherwise.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use tokio::runtime::Runtime;
+    /// use std::sync::Arc;
+    /// use whirlwind::ShardMap;
+    ///
+    /// let rt = Runtime::new().unwrap();
+    /// let map = Arc::new(ShardMap::new());
+    ///
+    /// rt.block_on(async {
+    ///     // Insert a new key-value pair.
+    ///     let inserted = map.compute_if_absent("foo", || "bar").await;
+    ///     assert_eq!(inserted, true);
+    ///     assert_eq!(map.get(&"foo").await.unwrap().value(), &"bar");
+    ///
+    ///     // Key already exists, no change.
+    ///     let inserted = map.compute_if_absent("foo", || "baz").await;
+    ///     assert_eq!(inserted, false);
+    ///     assert_eq!(map.get(&"foo").await.unwrap().value(), &"bar");
+    /// });
+    /// ```
+    pub async fn compute_if_absent<F>(&self, key: K, f: F) -> bool
+    where
+        F: FnOnce() -> V,
+    {
+        let mut inserted = false;
+        self.compute(key, |current| match current {
+            Some(value) => Some(value),
+            None => {
+                inserted = true;
+                Some(f())
+            }
+        })
+        .await;
+        inserted
+    }
 }

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -1,3 +1,4 @@
+use hashbrown::hash_table::Entry;
 use whirlwind::*;
 
 #[tokio::test]
@@ -64,4 +65,111 @@ async fn test_shardmap_is_empty() {
     assert_eq!(map.is_empty().await, false);
     map.remove(&"foo").await;
     assert_eq!(map.is_empty().await, true);
+}
+
+#[tokio::test]
+async fn test_shardmap_with_entry() {
+    let map = ShardMap::new();
+
+    // Test with vacant entry
+    let result = map
+        .with_entry("foo", |key, entry| {
+            assert_eq!(key, "foo");
+            match entry {
+                Entry::Vacant(slot) => {
+                    slot.insert((key, "bar"));
+                    Some("inserted")
+                }
+                Entry::Occupied(_) => None,
+            }
+        })
+        .await;
+    assert_eq!(result, Some("inserted"));
+    assert_eq!(map.get(&"foo").await.unwrap().value(), &"bar");
+    assert_eq!(map.len().await, 1);
+
+    // Test with occupied entry
+    let result = map
+        .with_entry("foo", |key, entry| {
+            assert_eq!(key, "foo");
+            assert!(
+                matches!(entry, Entry::Occupied(_)),
+                "Expected Occupied entry for existing key"
+            );
+            match entry {
+                Entry::Occupied(entry) => {
+                    let ((_, value), _) = entry.remove();
+                    Some(value)
+                }
+                Entry::Vacant(_) => None,
+            }
+        })
+        .await;
+    assert_eq!(result, Some("bar"));
+    assert_eq!(map.contains_key(&"foo").await, false);
+    assert_eq!(map.len().await, 0);
+}
+
+#[tokio::test]
+async fn test_shardmap_compute() {
+    let map = ShardMap::new();
+
+    // Test inserting new key-value pair
+    map.compute("foo", |current| {
+        assert_eq!(current, None);
+        Some("bar")
+    })
+    .await;
+    assert_eq!(map.get(&"foo").await.unwrap().value(), &"bar");
+    assert_eq!(map.len().await, 1);
+
+    // Test updating existing key
+    map.compute("foo", |current| {
+        assert_eq!(current, Some("bar"));
+        Some("baz")
+    })
+    .await;
+    assert_eq!(map.get(&"foo").await.unwrap().value(), &"baz");
+    assert_eq!(map.len().await, 1);
+
+    // Test removing key by returning None
+    map.compute("foo", |current| {
+        assert_eq!(current, Some("baz"));
+        None
+    })
+    .await;
+    assert_eq!(map.contains_key(&"foo").await, false);
+    assert_eq!(map.len().await, 0);
+
+    // Test no insertion when returning None for vacant entry
+    map.compute("foo", |current| {
+        assert_eq!(current, None);
+        None
+    })
+    .await;
+    assert_eq!(map.contains_key(&"foo").await, false);
+    assert_eq!(map.len().await, 0);
+}
+
+#[tokio::test]
+async fn test_shardmap_compute_if_absent() {
+    let map = ShardMap::new();
+
+    // Test inserting new key-value pair
+    let inserted = map.compute_if_absent("foo", || "bar").await;
+    assert_eq!(inserted, true);
+    assert_eq!(map.get(&"foo").await.unwrap().value(), &"bar");
+    assert_eq!(map.len().await, 1);
+
+    // Test no insertion when key exists
+    let inserted = map.compute_if_absent("foo", || "baz").await;
+    assert_eq!(inserted, false);
+    assert_eq!(map.get(&"foo").await.unwrap().value(), &"bar");
+    assert_eq!(map.len().await, 1);
+
+    // Test inserting another new key
+    let inserted = map.compute_if_absent("foo2", || "bar2").await;
+    assert_eq!(inserted, true);
+    assert_eq!(map.get(&"foo2").await.unwrap().value(), &"bar2");
+    assert_eq!(map.len().await, 2);
 }


### PR DESCRIPTION
Solves #15

I don't think we can get a proper `.entry(key)` function with how the shards and locks are done, but this `.with_entry(key, |key, entry| {})` api should be enough for most use-cases.

Also added functions `compute` and `compute_if_absent` that are basically just wrappers around `with_entry` to make it easier / more convenient to use, if you think that these don't belong in here, we can remove it, as `with_entry` will already be enough to get the job done.