### PR TITLE
feat: Implement stream iterator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -79,6 +101,95 @@ name = "foldhash"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
+
+[[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
 
 [[package]]
 name = "gimli"
@@ -185,6 +296,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -231,6 +348,12 @@ checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "slab"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"
@@ -304,7 +427,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 name = "whirlwind"
 version = "0.1.1"
 dependencies = [
+ "async-stream",
  "crossbeam-utils",
+ "futures",
  "hashbrown",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,15 @@ categories = ["asynchronous", "concurrency", "data-structures"]
 
 
 [dependencies]
+async-stream = { version = "0.3.6", optional = true }
 crossbeam-utils = "0.8.20"
+futures = { version = "0.3.31", optional = true }
 hashbrown = { version = "0.15.1" }
 tokio = { version = "1.41.0", features = ["sync"] }
 
 [dev-dependencies]
 tokio = { version = "1.41.0", features = ["full"] }
+
+[features]
+default = []
+stream = ["async-stream", "futures"]

--- a/src/shard_map.rs
+++ b/src/shard_map.rs
@@ -526,7 +526,6 @@ where
     ///     map.insert(2, "b".to_string()).await;
     ///
     ///     let s = map.stream_owned();
-    ///     pin_mut!(s); // Stream is not Unpin
     ///
     ///     let mut items = Vec::new();
     ///     while let Some((k, v)) = s.next().await {

--- a/src/shard_map.rs
+++ b/src/shard_map.rs
@@ -661,22 +661,18 @@ where
     K: Eq + std::hash::Hash + 'static,
     V: 'static,
 {
-    /// Iterate (&K, &V) for this shard.
     pub fn iter(&self) -> impl Iterator<Item = (&K, &V)> {
         self.guard.iter().map(|(k, v)| (k, v))
     }
 
-    /// Iterate keys by ref.
     pub fn keys(&self) -> impl Iterator<Item = &K> {
         self.guard.iter().map(|(k, _)| k)
     }
 
-    /// Iterate values by ref.
     pub fn values(&self) -> impl Iterator<Item = &V> {
         self.guard.iter().map(|(_, v)| v)
     }
 
-    /// Number of entries in this shard.
     pub fn len(&self) -> usize {
         self.guard.len()
     }

--- a/src/shard_map.rs
+++ b/src/shard_map.rs
@@ -30,10 +30,9 @@ use hashbrown::hash_table::Entry;
 use async_stream::stream;
 #[cfg(feature = "stream")]
 use futures::{
-    future::StreamExt,
     pin_mut,
     stream::{self, Stream},
-    Future,
+    StreamExt,
 };
 
 use crate::{
@@ -458,6 +457,7 @@ where
         }
     }
 
+    #[cfg(feature = "stream")]
     /// Stream over all shards in the map.
     ///
     /// Each item is a `ShardRead` that *holds a read-lock* on that shard while you iterate it
@@ -488,7 +488,6 @@ where
     ///     assert_eq!(seen, 2);
     /// });
     /// ```
-    #[cfg(feature = "stream")]
     pub fn stream_shards(&self) -> impl Stream<Item = ShardRead<'_, K, V>> + '_ {
         let total = self.inner.len();
 
@@ -507,6 +506,7 @@ where
         })
     }
 
+    #[cfg(feature = "stream")]
     /// Flattened stream of **owned** `(K, V)` items.
     ///
     /// Locks one shard at a time, snapshots (clones) its entries into a `Vec`, drops the lock,
@@ -536,7 +536,6 @@ where
     ///     assert_eq!(items, vec![(1, "a".into()), (2, "b".into())]);
     /// });
     /// ```
-    #[cfg(feature = "stream")]
     pub fn stream_owned(&self) -> impl Stream<Item = (K, V)> + '_
     where
         K: Clone,
@@ -558,6 +557,7 @@ where
         }
     }
 
+    #[cfg(feature = "stream")]
     /// Collect all entries into a `Vec<(K, V)>` by cloning.
     ///
     /// Iterates shard-by-shard, cloning items under a read lock, then releasing the lock
@@ -580,7 +580,6 @@ where
     ///     assert_eq!(items, vec![(1, "a".into()), (2, "b".into())]);
     /// });
     /// ```
-    #[cfg(feature = "stream")]
     pub async fn entries(&self) -> Vec<(K, V)>
     where
         K: Clone,
@@ -589,6 +588,7 @@ where
         self.stream_owned().collect::<Vec<(K, V)>>().await
     }
 
+    #[cfg(feature = "stream")]
     /// Collect all keys into a `Vec<K>` by cloning.
     ///
     /// # Example
@@ -608,17 +608,22 @@ where
     ///     assert_eq!(ks, vec![10, 20]);
     /// });
     /// ```
-    #[cfg(feature = "stream")]
     pub async fn keys(&self) -> Vec<K>
     where
         K: Clone,
     {
-        self.stream_owned()
-            .map(|(k, _v)| k)
-            .collect::<Vec<K>>()
-            .await
+        let shard_stream = self.stream_shards();
+        pin_mut!(shard_stream);
+        let mut keys = Vec::new();
+        while let Some(shard) = shard_stream.next().await {
+            let mut shard_keys: Vec<K> = shard.keys().cloned().collect();
+            drop(shard);
+            keys.append(&mut shard_keys);
+        }
+        keys
     }
 
+    #[cfg(feature = "stream")]
     /// Collect all values into a `Vec<V>` by cloning.
     ///
     /// # Example
@@ -638,15 +643,19 @@ where
     ///     assert_eq!(vs, vec!["a".to_string(), "b".to_string()]);
     /// });
     /// ```
-    #[cfg(feature = "stream")]
     pub async fn values(&self) -> Vec<V>
     where
         V: Clone,
     {
-        self.stream_owned()
-            .map(|(_k, v)| v)
-            .collect::<Vec<V>>()
-            .await
+        let shard_stream = self.stream_shards();
+        pin_mut!(shard_stream);
+        let mut values = Vec::new();
+        while let Some(shard) = shard_stream.next().await {
+            let mut shard_values: Vec<V> = shard.values().cloned().collect();
+            drop(shard);
+            values.append(&mut shard_values);
+        }
+        values
     }
 }
 

--- a/src/shard_map.rs
+++ b/src/shard_map.rs
@@ -526,6 +526,7 @@ where
     ///     map.insert(2, "b".to_string()).await;
     ///
     ///     let s = map.stream_owned();
+    ///     pin_mut!(s);
     ///
     ///     let mut items = Vec::new();
     ///     while let Some((k, v)) = s.next().await {

--- a/src/shard_map.rs
+++ b/src/shard_map.rs
@@ -26,6 +26,16 @@ use std::{
 use crossbeam_utils::CachePadded;
 use hashbrown::hash_table::Entry;
 
+#[cfg(feature = "stream")]
+use async_stream::stream;
+#[cfg(feature = "stream")]
+use futures::{
+    future::StreamExt,
+    pin_mut,
+    stream::{self, Stream},
+    Future,
+};
+
 use crate::{
     mapref::{MapRef, MapRefMut},
     shard::Shard,
@@ -167,8 +177,7 @@ where
         }
         let shard_capacity = cap / shards;
 
-        let shards = std::iter::repeat(())
-            .take(shards)
+        let shards = std::iter::repeat_n((), shards)
             .map(|_| CachePadded::new(Shard::with_capacity(shard_capacity)))
             .collect();
 
@@ -447,5 +456,232 @@ where
         for shard in self.inner.iter() {
             shard.write().await.clear();
         }
+    }
+
+    /// Stream over all shards in the map.
+    ///
+    /// Each item is a `ShardRead` that *holds a read-lock* on that shard while you iterate it
+    /// synchronously. Writes to **other shards** continue to proceed concurrently.
+    ///
+    /// # Example
+    /// ```
+    /// use tokio::runtime::Runtime;
+    /// use futures::{pin_mut, StreamExt};
+    /// use std::sync::Arc;
+    /// use whirlwind::ShardMap;
+    ///
+    /// let rt = Runtime::new().unwrap();
+    /// let map = Arc::new(ShardMap::new());
+    /// rt.block_on(async {
+    ///     map.insert(1, "a").await;
+    ///     map.insert(2, "b").await;
+    ///
+    ///     let shards = map.stream_shards();
+    ///     pin_mut!(shards); // Stream is not Unpin
+    ///
+    ///     let mut seen = 0;
+    ///     while let Some(sh) = shards.next().await {
+    ///         for (_k, _v) in sh.iter() {
+    ///             seen += 1;
+    ///         }
+    ///     }
+    ///     assert_eq!(seen, 2);
+    /// });
+    /// ```
+    #[cfg(feature = "stream")]
+    pub fn stream_shards(&self) -> impl Stream<Item = ShardRead<'_, K, V>> + '_ {
+        let total = self.inner.len();
+
+        stream::unfold(0usize, move |mut idx| async move {
+            if idx >= total {
+                return None;
+            }
+
+            // SAFETY: idx is checked against total above.
+            let shard = unsafe { self.inner.get_unchecked(idx) };
+
+            let guard = shard.read().await;
+
+            idx += 1;
+            Some((ShardRead { guard }, idx))
+        })
+    }
+
+    /// Flattened stream of **owned** `(K, V)` items.
+    ///
+    /// Locks one shard at a time, snapshots (clones) its entries into a `Vec`, drops the lock,
+    /// then yields items. This allows concurrent writes to other shards.
+    ///
+    /// # Example
+    /// ```
+    /// use tokio::runtime::Runtime;
+    /// use futures::{pin_mut, StreamExt};
+    /// use std::sync::Arc;
+    /// use whirlwind::ShardMap;
+    ///
+    /// let rt = Runtime::new().unwrap();
+    /// let map = Arc::new(ShardMap::new());
+    /// rt.block_on(async {
+    ///     map.insert(1, "a".to_string()).await;
+    ///     map.insert(2, "b".to_string()).await;
+    ///
+    ///     let s = map.stream_owned();
+    ///     pin_mut!(s); // Stream is not Unpin
+    ///
+    ///     let mut items = Vec::new();
+    ///     while let Some((k, v)) = s.next().await {
+    ///         items.push((k, v));
+    ///     }
+    ///     items.sort_by_key(|(k, _)| *k);
+    ///     assert_eq!(items, vec![(1, "a".into()), (2, "b".into())]);
+    /// });
+    /// ```
+    #[cfg(feature = "stream")]
+    pub fn stream_owned(&self) -> impl Stream<Item = (K, V)> + '_
+    where
+        K: Clone,
+        V: Clone,
+    {
+        let shard_stream = self.stream_shards();
+
+        stream! {
+            pin_mut!(shard_stream);
+
+            while let Some(shard) = shard_stream.next().await {
+                let items: Vec<(K, V)> =
+                    shard.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+                drop(shard);
+                for item in items {
+                    yield item;
+                }
+            }
+        }
+    }
+
+    /// Collect all entries into a `Vec<(K, V)>` by cloning.
+    ///
+    /// Iterates shard-by-shard, cloning items under a read lock, then releasing the lock
+    /// before pushing into the result.
+    ///
+    /// # Example
+    /// ```
+    /// use tokio::runtime::Runtime;
+    /// use std::sync::Arc;
+    /// use whirlwind::ShardMap;
+    ///
+    /// let rt = Runtime::new().unwrap();
+    /// let map = Arc::new(ShardMap::new());
+    /// rt.block_on(async {
+    ///     map.insert(1, "a".to_string()).await;
+    ///     map.insert(2, "b".to_string()).await;
+    ///
+    ///     let mut items = map.entries().await;
+    ///     items.sort_by_key(|(k, _)| *k);
+    ///     assert_eq!(items, vec![(1, "a".into()), (2, "b".into())]);
+    /// });
+    /// ```
+    #[cfg(feature = "stream")]
+    pub async fn entries(&self) -> Vec<(K, V)>
+    where
+        K: Clone,
+        V: Clone,
+    {
+        self.stream_owned().collect::<Vec<(K, V)>>().await
+    }
+
+    /// Collect all keys into a `Vec<K>` by cloning.
+    ///
+    /// # Example
+    /// ```
+    /// use tokio::runtime::Runtime;
+    /// use std::sync::Arc;
+    /// use whirlwind::ShardMap;
+    ///
+    /// let rt = Runtime::new().unwrap();
+    /// let map = Arc::new(ShardMap::new());
+    /// rt.block_on(async {
+    ///     map.insert(10, "x").await;
+    ///     map.insert(20, "y").await;
+    ///
+    ///     let mut ks = map.keys().await;
+    ///     ks.sort();
+    ///     assert_eq!(ks, vec![10, 20]);
+    /// });
+    /// ```
+    #[cfg(feature = "stream")]
+    pub async fn keys(&self) -> Vec<K>
+    where
+        K: Clone,
+    {
+        self.stream_owned()
+            .map(|(k, _v)| k)
+            .collect::<Vec<K>>()
+            .await
+    }
+
+    /// Collect all values into a `Vec<V>` by cloning.
+    ///
+    /// # Example
+    /// ```
+    /// use tokio::runtime::Runtime;
+    /// use std::sync::Arc;
+    /// use whirlwind::ShardMap;
+    ///
+    /// let rt = Runtime::new().unwrap();
+    /// let map = Arc::new(ShardMap::new());
+    /// rt.block_on(async {
+    ///     map.insert(1, "a".to_string()).await;
+    ///     map.insert(2, "b".to_string()).await;
+    ///
+    ///     let mut vs = map.values().await;
+    ///     vs.sort();
+    ///     assert_eq!(vs, vec!["a".to_string(), "b".to_string()]);
+    /// });
+    /// ```
+    #[cfg(feature = "stream")]
+    pub async fn values(&self) -> Vec<V>
+    where
+        V: Clone,
+    {
+        self.stream_owned()
+            .map(|(_k, v)| v)
+            .collect::<Vec<V>>()
+            .await
+    }
+}
+
+#[cfg(feature = "stream")]
+pub struct ShardRead<'a, K, V> {
+    guard: crate::shard::ShardReader<'a, K, V>,
+}
+
+#[cfg(feature = "stream")]
+impl<'a, K, V> ShardRead<'a, K, V>
+where
+    K: Eq + std::hash::Hash + 'static,
+    V: 'static,
+{
+    /// Iterate (&K, &V) for this shard.
+    pub fn iter(&self) -> impl Iterator<Item = (&K, &V)> {
+        self.guard.iter().map(|(k, v)| (k, v))
+    }
+
+    /// Iterate keys by ref.
+    pub fn keys(&self) -> impl Iterator<Item = &K> {
+        self.guard.iter().map(|(k, _)| k)
+    }
+
+    /// Iterate values by ref.
+    pub fn values(&self) -> impl Iterator<Item = &V> {
+        self.guard.iter().map(|(_, v)| v)
+    }
+
+    /// Number of entries in this shard.
+    pub fn len(&self) -> usize {
+        self.guard.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.guard.len() == 0
     }
 }

--- a/src/shard_set.rs
+++ b/src/shard_set.rs
@@ -120,4 +120,13 @@ where
     pub async fn clear(&self) {
         self.inner.clear().await;
     }
+
+    /// Returns a vector of all values in the set.
+    #[cfg(feature = "stream")]
+    pub async fn values(&self) -> Vec<T>
+    where
+        T: Clone,
+    {
+        self.inner.keys().await
+    }
 }


### PR DESCRIPTION
As mentioned in #17, your preferred strategy is to use a Stream-based approach so that we don’t need to hold read locks on all shards simultaneously. This PR is a best-effort implementation of that approach.

`stream_owned` streams cloned `(K, V)` items by acquiring a read lock on one shard at a time, cloning its contents, and then releasing the lock before yielding. This allows concurrent writes to other shards to continue while iteration proceeds.

`stream_shards` is a best-effort attempt to provide a borrowed stream of entries `(&K, &V)` without cloning. Achieving fully borrowed iteration across asynchronous boundaries would require deeper changes to whirlwind internals (for example, storing shard data in Arc or using a custom pinned stream type), which could impact performance and complexity. For now, this implementation yields `ShardRead` guards one shard at a time, so by-reference iteration is possible per-shard, but not across shards concurrently.

Implements `keys`, `values` and `entries` for `K` and `V` that implement `Clone`.

In summary:

- Avoids locking all shards at once
- Supports concurrent writes during iteration
- Still clones values for stream_owned to keep lifetimes sound
- Borrowed streaming remains limited to one shard at a time without structural changes

I have put all of this behind a `stream` feature as it doesn't seem to be an extremely in-demand feature.